### PR TITLE
Test changes to git_repository_url_open_to_public_contributors proper…

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,5 +1,6 @@
 {
   "build_entry_point": "BuildAzureContent.ps1",
+  "git_repository_url_open_to_public_contributors": "https://github.com/Azure/azure-content/",
   "skip_source_output_uploading": true,
   "docsets_to_publish": [
     {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,6 +1,6 @@
 {
   "build_entry_point": "BuildAzureContent.ps1",
-  "git_repository_url_open_to_public_contributors": "https://github.com/Azure/azure-content/",
+  "git_repository_url_open_to_public_contributors": "https://github.com/Azure/azure-content",
   "skip_source_output_uploading": true,
   "docsets_to_publish": [
     {


### PR DESCRIPTION
…ty, to point contributors to ACOM repo instead of OPS